### PR TITLE
Use height instead of max-height

### DIFF
--- a/src/components/wrapper.vue
+++ b/src/components/wrapper.vue
@@ -91,7 +91,7 @@
 
 <style>
     .v-collapse-content{
-        max-height: 0;
+        height: 0;
         transition: max-height 0.3s ease-out;
         overflow: hidden;
         padding: 0;
@@ -99,6 +99,6 @@
 
     .v-collapse-content-end{
         transition: max-height 0.3s ease-in;
-        max-height: 500px;
+        height: auto;
     }
 </style>


### PR DESCRIPTION
Fixes rendering for wrapper taller than 500px