### PR TITLE
Bind the status on the slot

### DIFF
--- a/src/components/wrapper.vue
+++ b/src/components/wrapper.vue
@@ -1,6 +1,6 @@
 <template>
     <div :class="'vc-' + $options.$vc.settings.basename">
-        <slot></slot>
+        <slot v-bind:status="status"></slot>
     </div>
 </template>
 


### PR DESCRIPTION
This would allow to access the status of the wrapper within the inner content of the wrapper by using the slot scope property when writing the content.